### PR TITLE
fix: revert "Merge branch 'main' into main"

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,5 @@
 # Código de Conduta da Pessoa Colaboradora
 
+[English Version](/CODE_OF_CONDUCT_EN.md)
+
 Como um dos repositórios sob a organização Cumbuca Dev GitHub, este repositório segue o [Código de Conduta da Cumbuca Dev](https://github.com/cumbucadev/contributions/blob/main/CODE_OF_CONDUCT.md).

--- a/CODE_OF_CONDUCT_EN.md
+++ b/CODE_OF_CONDUCT_EN.md
@@ -1,0 +1,5 @@
+# Contributor Code of Conduct
+
+[Versão em Português](/CODE_OF_CONDUCT.md)
+
+As one of the repositories under the Cumbuca Dev GitHub organization, this repository follows the [Cumbuca Dev Code of Conduct](https://github.com/cumbucadev/contributions/blob/main/CODE_OF_CONDUCT_EN.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,5 @@
 # Contribuindo
 
+[English Version](/CONTRIBUTING_EN.md)
+
 Obrigado por dedicar o seu tempo para contribuir! 🙇‍♀️🙇‍♂️ Toda ajuda é bem-vinda!

--- a/CONTRIBUTING_EN.md
+++ b/CONTRIBUTING_EN.md
@@ -1,0 +1,5 @@
+# Contributing
+
+[Versão em Português](/CONTRIBUTING.md)
+
+Thanks for taking the time to contribute! 🙇‍♀️🙇‍♂️ Every little bit of help counts!

--- a/CORE_TEAM_EN.md
+++ b/CORE_TEAM_EN.md
@@ -1,0 +1,31 @@
+# Core Team <nome-do-repo>
+
+[Versão em Português](/CORE_TEAM.md)
+
+The _Core Team_ of `cumbucadev/<nome-do-repo>` is comprised of a group of contributors who have demonstrated remarkable enthusiasm for the project and the community. This team holds administrative privileges on GitHub specific to this repository.
+
+## Responsibilities
+
+The _Core Team_ of `<nome-do-repo>` has the following responsibilities:
+
+* Be available to address strategic inquiries regarding the vision and future prospects of Brazilian Utils Python.
+
+* Commit to reviewing pull requests that have been submitted for some time or have been overlooked.
+
+* Periodically inspect open issues in Brazilian Utils Python, provide constructive suggestions, and categorize them using specific labels on GitHub.
+
+* Identify promising individuals in the Brazilian Utils Python community who may express interest in joining the team and contributing significantly.
+
+    Similar to all contributors at `<nome-do-repo>`, members of the Core Team also operate as volunteers in the open-source realm; being part of the team is not an obligation. This team is recognized as leaders in this community, and while they are a reliable reference for obtaining answers to questions, it's important to note that they contribute voluntarily, dedicating their time, which may result in non-immediate availability.
+
+## Members
+
+* <https://github.com/orgs/cumbucadev/teams/cumbuca-s-core-team>
+
+## Adding New Members
+
+The process for incorporating new members into the _Core Team_ `<nome-do-repo>` is as follows:
+
+* An existing team member privately contacts the individual to gauge their interest. If there is interest, a pull request is opened, adding the new member to the list.
+
+* Other team members review the pull request. The person responsible for merging the PR is also tasked with adding the new member to the Core Team group on GitHub.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
 
 # <nome-do-repositório>
 
+[English Version](/README_EN.md)
+
 ## 💬 Novos Funcionalidades e Reportar Bugs
 
 Caso queira sugerir novas funcionalidades ou reportar bugs, basta criar
@@ -36,8 +38,11 @@ interagir por lá!
 Sua colaboração é sempre muito bem-vinda! Para facilitar seus primeiros passos, preparamos os seguintes arquivos:
 
 - [CONTRIBUTING.md](/CONTRIBUTING.md): Aqui você encontrará todas as instruções necessárias para contribuir com o projeto.
+- [CONTRIBUTING_EN.md](/CONTRIBUTING_EN.md): Versão em inglês das diretrizes de contribuição.
 - [CODE_OF_CONDUCT.md](/CODE_OF_CONDUCT.md): Nosso código de conduta, que define as expectativas para interações respeitosas e inclusivas dentro da comunidade.
+- [CODE_OF_CONDUCT_EN.md](/CODE_OF_CONDUCT_EN.md): Versão em inglês do código de conduta.
 - [CORE_TEAM.md](/CORE_TEAM.md): Lista e apresenta informações sobre as pessoas integrantes do time principal do projeto, incluindo suas funções e formas de contato.
+- [CORE_TEAM_EN.md](CORE_TEAM_EN.md): Versão em inglês da lista e informações sobre o time principal do projeto.
 - [LICENSE.md](/LICENSE.md): Detalhes sobre a licença do projeto. Ela define o que você pode e não pode fazer com o código. Em geral, a licença permite que você use, modifique e distribua o código, desde que siga os termos definidos. No entanto, é importante verificar se há restrições específicas, como atribuição de crédito ao autor original ou proibição de uso comercial.
 
 Certifique-se de ler esses arquivos com atenção antes de contribuir. Se tiver qualquer dificuldade ou dúvida, não hesite em nos perguntar utilizando o [GitHub Discussions][github-discussions]. Toda ajuda conta!

--- a/README_EN.md
+++ b/README_EN.md
@@ -1,0 +1,54 @@
+<div align="center">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://github.com/cumbucadev/design/raw/main/images/logo-dark-transparent.png"
+    >
+    <img
+      alt="Logo do Cumbuca Dev"
+      src="https://github.com/cumbucadev/design/raw/main/images/logo-light-transparent.png"
+      width="20%"
+    >
+  </picture>
+</div>
+
+# <nome-do-repositório>
+
+[Versão em Português](/README.md)
+
+## 💬 New Features and Reporting Bugs
+
+If you would like to suggest new features or report bugs, just create a new [issue][github-issues] and we will respond there!
+
+(To learn more about GitHub issues, check out the [official GitHub documentation][github-issues-doc]).
+
+## 💡 Questions? Ideas?
+
+Do you have questions about how to use the library? New ideas for the project? Want to share something with us? Feel free to create a topic in our [Discussions][github-discussions], and we’ll interact with you there!
+
+(To learn more about GitHub discussions, check out the [official GitHub documentation][github-discussions-doc]).
+
+## 💻 Contributing to the Project's Code
+
+Your contribution is always very welcome! To help you get started, we’ve prepared the following files:
+
+- [CONTRIBUTING.md](/CONTRIBUTING.md): Here you’ll find all the necessary instructions to contribute to the project.
+- [CONTRIBUTING_EN.md](/CONTRIBUTING_EN.md): English version of the contribution guidelines.
+- [CODE_OF_CONDUCT.md](/CODE_OF_CONDUCT.md): Our code of conduct, which defines expectations for respectful and inclusive interactions within the community.
+- [CODE_OF_CONDUCT_EN.md](/CODE_OF_CONDUCT_EN.md): English version of the code of conduct.
+- [CORE_TEAM.md](/CORE_TEAM.md): Lists and presents information about the members of the project’s core team, including their roles and contact details.
+- [CORE_TEAM_EN.md](CORE_TEAM_EN.md): English version of the list and information about the project’s core team.
+- [LICENSE.md](/LICENSE.md): Details about the project’s license. It defines what you can and cannot do with the code. In general, the license allows you to use, modify, and distribute the code as long as you follow the defined terms. However, it’s important to check for specific restrictions, such as credit attribution to the original author or prohibition of commercial use.
+
+Make sure to read these files carefully before contributing. If you have any difficulties or questions, feel free to ask us using [GitHub Discussions][github-discussions]. Every bit of help counts!
+
+## ❤️ Contributors
+
+[![contributors](https://contrib.rocks/image?repo=cumbucadev/generic-template)](https://github.com/cumbucadev/generic-template/graphs/contributors)
+
+_Made with [contrib.rocks](https://contrib.rocks)._
+
+[github-discussions-doc]: https://docs.github.com/discussions
+[github-discussions]: https://github.com/cumbucadev/<nome-do-repositório>/discussions
+[github-issues-doc]: https://docs.github.com/issues/tracking-your-work-with-issues/creating-an-issue
+[github-issues]: https://github.com/cumbucadev/<nome-do-repositório>/issues


### PR DESCRIPTION
This reverts commit e20331152a3a469c25a7b0c92ccb6ba025d9698f, reversing changes made to 738bebfca07cc29b868018e8cb4350827ed456f4.

I merged it by mistake. The english files should be here. They should only be deleted from this repo: https://github.com/cumbucadev/generic-template-pt